### PR TITLE
Switch from mean to sum for histograms to simplify calculations

### DIFF
--- a/collectors/monitoring_metrics.go
+++ b/collectors/monitoring_metrics.go
@@ -102,13 +102,13 @@ type HistogramMetric struct {
 
 func (t *timeSeriesMetrics) CollectNewConstHistogram(timeSeries *monitoring.TimeSeries, reportTime time.Time, labelKeys []string, dist *monitoring.Distribution, buckets map[float64]uint64, labelValues []string, metricKind string) {
 	fqName := buildFQName(timeSeries)
-
+	histogramSum := dist.Mean * float64(dist.Count)
 	var v HistogramMetric
 	if t.fillMissingLabels || (metricKind == "DELTA" && t.aggregateDeltas) {
 		v = HistogramMetric{
 			FqName:         fqName,
 			LabelKeys:      labelKeys,
-			Sum:            dist.Mean * float64(dist.Count),
+			Sum:            histogramSum,
 			Count:          uint64(dist.Count),
 			Buckets:        buckets,
 			LabelValues:    labelValues,
@@ -133,7 +133,7 @@ func (t *timeSeriesMetrics) CollectNewConstHistogram(timeSeries *monitoring.Time
 		return
 	}
 
-	t.ch <- t.newConstHistogram(fqName, reportTime, labelKeys, dist.Mean, uint64(dist.Count), buckets, labelValues)
+	t.ch <- t.newConstHistogram(fqName, reportTime, labelKeys, histogramSum, uint64(dist.Count), buckets, labelValues)
 }
 
 func (t *timeSeriesMetrics) newConstHistogram(fqName string, reportTime time.Time, labelKeys []string, sum float64, count uint64, buckets map[float64]uint64, labelValues []string) prometheus.Metric {

--- a/collectors/monitoring_metrics.go
+++ b/collectors/monitoring_metrics.go
@@ -100,6 +100,17 @@ type HistogramMetric struct {
 	KeysHash uint64
 }
 
+func (h *HistogramMetric) MergeHistogram(other *HistogramMetric) {
+	// Increment totals based on incoming totals
+	h.Sum += other.Sum
+	h.Count += other.Count
+
+	// Merge the buckets from existing in to current
+	for key, value := range other.Buckets {
+		h.Buckets[key] += value
+	}
+}
+
 func (t *timeSeriesMetrics) CollectNewConstHistogram(timeSeries *monitoring.TimeSeries, reportTime time.Time, labelKeys []string, dist *monitoring.Distribution, buckets map[float64]uint64, labelValues []string, metricKind string) {
 	fqName := buildFQName(timeSeries)
 	histogramSum := dist.Mean * float64(dist.Count)

--- a/delta/histogram_test.go
+++ b/delta/histogram_test.go
@@ -29,15 +29,17 @@ var _ = Describe("HistogramStore", func() {
 	var store *delta.InMemoryHistogramStore
 	var histogram *collectors.HistogramMetric
 	descriptor := &monitoring.MetricDescriptor{Name: "This is a metric"}
+	bucketKey := 1.00000000000000000001
+	bucketValue := uint64(1000)
 
 	BeforeEach(func() {
 		store = delta.NewInMemoryHistogramStore(promlog.New(&promlog.Config{}), time.Minute)
 		histogram = &collectors.HistogramMetric{
 			FqName:         "histogram_name",
 			LabelKeys:      []string{"labelKey"},
-			Mean:           10,
+			Sum:            10,
 			Count:          100,
-			Buckets:        map[float64]uint64{1.00000000000000000001: 1000},
+			Buckets:        map[float64]uint64{bucketKey: bucketValue},
 			LabelValues:    []string{"labelValue"},
 			ReportTime:     time.Now().Truncate(time.Second),
 			CollectionTime: time.Now().Truncate(time.Second),
@@ -51,6 +53,34 @@ var _ = Describe("HistogramStore", func() {
 
 		Expect(len(metrics)).To(Equal(1))
 		Expect(metrics[0]).To(Equal(histogram))
+	})
+
+	It("can merge histograms", func() {
+		store.Increment(descriptor, histogram)
+
+		// Shallow copy and change report time so they will merge
+		nextValue := &collectors.HistogramMetric{
+			FqName:         "histogram_name",
+			LabelKeys:      []string{"labelKey"},
+			Sum:            10,
+			Count:          100,
+			Buckets:        map[float64]uint64{bucketKey: bucketValue},
+			LabelValues:    []string{"labelValue"},
+			ReportTime:     time.Now().Truncate(time.Second).Add(time.Second),
+			CollectionTime: time.Now().Truncate(time.Second),
+			KeysHash:       8765,
+		}
+
+		store.Increment(descriptor, nextValue)
+
+		metrics := store.ListMetrics(descriptor.Name)
+
+		Expect(len(metrics)).To(Equal(1))
+		histogram := metrics[0]
+		Expect(histogram.Count).To(Equal(uint64(200)))
+		Expect(histogram.Sum).To(Equal(20.0))
+		Expect(len(histogram.Buckets)).To(Equal(1))
+		Expect(histogram.Buckets[bucketKey]).To(Equal(bucketValue * 2))
 	})
 
 	It("will remove histograms outside of TTL", func() {


### PR DESCRIPTION
The current logic for merging a histogram has some incorrect math for how the mean is merged. The end result of this is that the `sum` can go up and down causing all sorts of problems with histogram calculations,
![image](https://github.com/prometheus-community/stackdriver_exporter/assets/4571540/3eff07c3-0c08-41e8-a31d-92eddc067402)

At the end of the day we don't really care about the `mean` value the histogram only wants the sum. Instead of trying to properly merge two `mean` values this PR switches to calculating the sum for the histogram and increasing that value as new data arrives. This should ensure an ever increasing `sum` as prometheus expects unless GCP produces a distribution with a negative mean which should hopefully never happen.